### PR TITLE
add option to use rails ajax

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -22,6 +22,21 @@
                             retry_count: retry_count,
                             interval: interval,
                             turbolinks: RenderAsync.configuration.turbolinks } %>
+    <% elsif %>
+      <%= render partial: 'render_async/request_rails_ujs',
+                 formats: [:js],
+                 locals:  { container_id: container_id,
+                            path: path,
+                            method: method,
+                            data: data,
+                            event_name: event_name,
+                            toggle: toggle,
+                            headers: headers,
+                            error_message: error_message,
+                            error_event_name: error_event_name,
+                            retry_count: retry_count,
+                            interval: interval,
+                            turbolinks: RenderAsync.configuration.turbolinks } %>
     <% else %>
       <%= render partial: 'render_async/request_vanilla',
                  formats: [:js],

--- a/app/views/render_async/_request_rails_ajax.js.erb
+++ b/app/views/render_async/_request_rails_ajax.js.erb
@@ -1,0 +1,141 @@
+if (window.jQuery) {
+  (function($) {
+    <% if turbolinks %>
+    if (document.documentElement.hasAttribute("data-turbolinks-preview")) {
+      return;
+    }
+    <% end %>
+    function createEvent(name, container) {
+      var event = undefined;
+      if (typeof(Event) === 'function') {
+        event = new Event(name);
+      } else {
+        event = document.createEvent('Event');
+        event.initEvent(name, true, true);
+      }
+      event.container = container
+      return event;
+    }
+
+    function _runAfterDocumentLoaded(callback) {
+      if (document.readyState === 'complete' || document.readyState === 'interactive') {
+        // Handle a case where nested partials get loaded after the document loads
+        callback();
+      } else {
+        <% if turbolinks %>
+        $(document).one('turbolinks:load', callback);
+        <% else %>
+        $(document).ready(callback);
+        <% end %>
+      }
+    }
+
+    function _makeRequest(currentRetryCount) {
+      var headers = <%= headers.to_json.html_safe %>;
+      var csrfTokenElement = document.querySelector('meta[name="csrf-token"]')
+      if (csrfTokenElement)
+        headers['X-CSRF-Token'] = csrfTokenElement.content
+
+      Rails.ajax({
+        url: '<%= path.html_safe %>',
+        type: '<%= method %>',
+        data: "<%= escape_javascript(data.to_s.html_safe) %>",
+        headers: headers,
+        onSuccess: onSuccess,
+        onError: onError
+      })
+
+      function onSuccess(response){
+        var container = $("#<%= container_id %>");
+        <% if interval %>
+          container.empty();
+          container.append(response);
+        <% else %>
+          container.replaceWith(response);
+        <% end %>
+
+        var loadEvent = createEvent('render_async_load', container);
+        document.dispatchEvent(loadEvent);
+
+        <% if event_name.present? %>
+          var event = createEvent("<%= event_name %>", container)
+          document.dispatchEvent(event);
+        <% end %>
+  }
+
+  function onError(response){
+        var skipErrorMessage = false;
+        <% if retry_count > 0 %>
+        skipErrorMessage = retry(currentRetryCount)
+        <% end %>
+
+        if (skipErrorMessage) return;
+
+        var container = $("#<%= container_id %>");
+        container.replaceWith("<%= error_message.try(:html_safe) %>");
+
+        var errorEvent = createEvent('render_async_error', container);
+        errorEvent.container = container;
+        document.dispatchEvent(errorEvent);
+
+        <% if error_event_name.present? %>
+          var event = createEvent("<%= error_event_name %>", container)
+          document.dispatchEvent(event);
+        <% end %>
+  }
+    };
+
+    <% if retry_count > 0 %>
+    function retry(currentRetryCount) {
+      if (typeof(currentRetryCount) === 'number') {
+        if (currentRetryCount >= <%= retry_count %>)
+          return false;
+
+        _makeRequest(currentRetryCount + 1);
+        return true;
+      }
+
+      _makeRequest(1);
+      return true;
+    }
+    <% end %>
+
+    var _renderAsyncFunction = _makeRequest;
+
+    var _interval;
+    <% if interval %>
+    var _renderAsyncFunction = function() {
+      _makeRequest();
+      _interval = setInterval(_makeRequest, <%= interval %>);
+    }
+
+    <% if turbolinks %>
+    $(document).one('turbolinks:visit', function() {
+      if (typeof(_interval) === 'number') {
+        clearInterval(_interval)
+        _interval = undefined;
+      }
+    });
+    <% end %>
+    <% end %>
+
+    <% if toggle %>
+    function _setUpToggle() {
+      $(document).<%= toggle[:once] ? 'one' : 'on' %>('<%= toggle[:event] || 'click' %>', '<%= toggle[:selector] %>', function(event) {
+        if (typeof(_interval) === 'number') {
+          clearInterval(_interval);
+          _interval = undefined;
+        } else {
+          _renderAsyncFunction();
+        }
+      });
+    }
+
+    _runAfterDocumentLoaded(_setUpToggle);
+    <% elsif !toggle %>
+    _runAfterDocumentLoaded(_renderAsyncFunction)
+    <% end %>
+  }(jQuery));
+} else {
+  console.warn("Looks like you've enabled jQuery for render_async, but jQuery is not defined on the window object");
+};

--- a/app/views/render_async/_request_rails_ujs.js.erb
+++ b/app/views/render_async/_request_rails_ujs.js.erb
@@ -1,5 +1,5 @@
-if (window.jQuery) {
-  (function($) {
+if (window.Rails) {
+  (function() {
     <% if turbolinks %>
     if (document.documentElement.hasAttribute("data-turbolinks-preview")) {
       return;
@@ -41,17 +41,23 @@ if (window.jQuery) {
         type: '<%= method %>',
         data: "<%= escape_javascript(data.to_s.html_safe) %>",
         headers: headers,
-        onSuccess: onSuccess,
-        onError: onError
-      })
+        success: onSuccess,
+        error: onError
+      });
 
-      function onSuccess(response){
+      function onSuccess(response, status, xmlRequest){
         var container = $("#<%= container_id %>");
+        const contentTypeJS = xmlRequest.getResponseHeader("Content-Type").includes("text/javascript");
+
         <% if interval %>
-          container.empty();
-          container.append(response);
+          if(!contentTypeJS){
+            container.empty();
+            container.append(response);
+          }
         <% else %>
-          container.replaceWith(response);
+          if(!contentTypeJS){
+            container.replaceWith(response);
+          }
         <% end %>
 
         var loadEvent = createEvent('render_async_load', container);
@@ -61,7 +67,7 @@ if (window.jQuery) {
           var event = createEvent("<%= event_name %>", container)
           document.dispatchEvent(event);
         <% end %>
-  }
+     }
 
   function onError(response){
         var skipErrorMessage = false;
@@ -82,7 +88,7 @@ if (window.jQuery) {
           var event = createEvent("<%= error_event_name %>", container)
           document.dispatchEvent(event);
         <% end %>
-  }
+     }
     };
 
     <% if retry_count > 0 %>
@@ -135,7 +141,7 @@ if (window.jQuery) {
     <% elsif !toggle %>
     _runAfterDocumentLoaded(_renderAsyncFunction)
     <% end %>
-  }(jQuery));
+  }());
 } else {
-  console.warn("Looks like you've enabled jQuery for render_async, but jQuery is not defined on the window object");
+  console.warn("Looks like you've enabled rails_ujs for render_async, but Rails is not defined on the window object");
 };

--- a/app/views/render_async/_request_rails_ujs.js.erb
+++ b/app/views/render_async/_request_rails_ujs.js.erb
@@ -31,16 +31,10 @@ if (window.Rails) {
     }
 
     function _makeRequest(currentRetryCount) {
-      var headers = <%= headers.to_json.html_safe %>;
-      var csrfTokenElement = document.querySelector('meta[name="csrf-token"]')
-      if (csrfTokenElement)
-        headers['X-CSRF-Token'] = csrfTokenElement.content
-
       Rails.ajax({
         url: '<%= path.html_safe %>',
         type: '<%= method %>',
         data: "<%= escape_javascript(data.to_s.html_safe) %>",
-        headers: headers,
         success: onSuccess,
         error: onError
       });

--- a/lib/render_async/configuration.rb
+++ b/lib/render_async/configuration.rb
@@ -1,11 +1,11 @@
 module RenderAsync
   class Configuration
-    attr_accessor :jquery, :turbolinks, :rails_ajax
+    attr_accessor :jquery, :turbolinks, :rails_ujs
 
     def initialize
       @jquery = false
       @turbolinks = false
-      @rails_ajax = false
+      @rails_ujs = false
     end
   end
 end

--- a/lib/render_async/configuration.rb
+++ b/lib/render_async/configuration.rb
@@ -1,10 +1,11 @@
 module RenderAsync
   class Configuration
-    attr_accessor :jquery, :turbolinks
+    attr_accessor :jquery, :turbolinks, :rails_ajax
 
     def initialize
       @jquery = false
       @turbolinks = false
+      @rails_ajax = false
     end
   end
 end


### PR DESCRIPTION
why: when we are polling we want to have javascript to be executed in the response. rails ajax makes it so we can execute it without a CSP error